### PR TITLE
Allow positioning relative to parent container

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The `notify` function can either be passed a string or an object.  When passing 
 * `scope` - Optional.  A valid Angular scope object.  The scope of the template will be created by calling `$new()` on this scope.
 * `position` - Optional.  `center`, `left` and `right` are the only acceptable values.
 * `container` - Optional.  Element that contains each notification.  Defaults to `document.body`.
+* `parentalPosition` - Optional.  Boolean for whether or not the notification should be positioned absolutely from it container intead of CSS position:fixed. Requires the parent to have position:relative.
 
 This function will return an object with a `close()` method and a `message` property.
 

--- a/angular-notify.css
+++ b/angular-notify.css
@@ -34,6 +34,14 @@
     right:15px;
 }
 
+.cg-notify-message-parental-position{
+  position: absolute;
+}
+
+.cg-notify-notification-parent{
+  position: relative;
+}
+
 .cg-notify-message a {
     font-weight:bold;
     color:inherit;

--- a/angular-notify.html
+++ b/angular-notify.html
@@ -1,7 +1,8 @@
 <div class="cg-notify-message" ng-class="[$classes, 
     $position === 'center' ? 'cg-notify-message-center' : '',
     $position === 'left' ? 'cg-notify-message-left' : '',
-    $position === 'right' ? 'cg-notify-message-right' : '']"
+    $position === 'right' ? 'cg-notify-message-right' : '',
+    $parentalPosition === true ? 'cg-notify-message-parental-position' : '']"
     ng-style="{'margin-left': $centerMargin}">
 
     <div ng-show="!$messageTemplate">

--- a/angular-notify.js
+++ b/angular-notify.js
@@ -8,7 +8,7 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
         var position = 'center';
         var container = document.body;
         var maximumOpen = 0;
-
+        var parentalPosition = false;
         var messageElements = [];
         var openNotificationsScope = [];
 
@@ -21,12 +21,14 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
             args.duration = args.duration ? args.duration : defaultDuration;
             args.templateUrl = args.templateUrl ? args.templateUrl : defaultTemplateUrl;
             args.container = args.container ? args.container : container;
+            args.parentalPosition = args.parentalPosition ? args.parentalPosition : parentalPosition;
             args.classes = args.classes ? args.classes : '';
 
             var scope = args.scope ? args.scope.$new() : $rootScope.$new();
             scope.$position = args.position ? args.position : position;
             scope.$message = args.message;
             scope.$classes = args.classes;
+            scope.$parentalPosition = args.parentalPosition;
             scope.$messageTemplate = args.messageTemplate;
 
             if (maximumOpen > 0) {
@@ -63,6 +65,10 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
                     } else {
                         throw new Error('cgNotify could not find the .cg-notify-message-template element in '+args.templateUrl+'.');
                     }
+                }
+
+                if (args.parentalPosition === true){
+                  angular.element(args.container).addClass('cg-notify-notification-parent');
                 }
 
                 angular.element(args.container).append(templateElement);
@@ -142,6 +148,7 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
             position = !angular.isUndefined(args.position) ? args.position : position;
             container = args.container ? args.container : container;
             maximumOpen = args.maximumOpen ? args.maximumOpen : maximumOpen;
+            parentalPosition = args.parentalPosition ? args.parentalPosition : parentalPosition;
         };
 
         notify.closeAll = function(){


### PR DESCRIPTION
I found myself a little surprised that setting the parent container didn't actually make the notification appear relative to that container.  We needed the notifications to appear closer to the user's point of focus (a particular form or element on the page) and I figured it might be useful addition to the project. Usage:

  notify.config({
    parentalPosition: true,
    container: $('#order-detail')
  });

left / center / right work as expected.
