### PR TITLE
fix: notify() with duration set to 0

### DIFF
--- a/angular-notify.js
+++ b/angular-notify.js
@@ -18,7 +18,7 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
                 args = {message:args};
             }
 
-            args.duration = args.duration ? args.duration : defaultDuration;
+            args.duration = !angular.isUndefined(args.duration) ? args.duration : defaultDuration;
             args.templateUrl = args.templateUrl ? args.templateUrl : defaultTemplateUrl;
             args.container = args.container ? args.container : container;
             args.classes = args.classes ? args.classes : '';
@@ -40,7 +40,7 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
 
                 var templateElement = $compile(template)(scope);
                 templateElement.bind('webkitTransitionEnd oTransitionEnd otransitionend transitionend msTransitionEnd', function(e){
-                    if (e.propertyName === 'opacity' || e.currentTarget.style.opacity === 0 || 
+                    if (e.propertyName === 'opacity' || e.currentTarget.style.opacity === 0 ||
                         (e.originalEvent && e.originalEvent.propertyName === 'opacity')){
 
                         templateElement.remove();
@@ -112,7 +112,7 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
             });
 
             var retVal = {};
-            
+
             retVal.close = function(){
                 if (scope.$close){
                     scope.$close();


### PR DESCRIPTION
The notify function had a different check than the config function. Has a result, a notification called with a time of 0 was still closing after 10 seconds. The documentation is indicating that the notification should stay forever in this case.
