### PR TITLE
sticky messages with duration zero, fixes #67

### DIFF
--- a/dist/angular-notify.js
+++ b/dist/angular-notify.js
@@ -18,7 +18,7 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
                 args = {message:args};
             }
 
-            args.duration = args.duration ? args.duration : defaultDuration;
+            args.duration = !angular.isUndefined(args.duration) ? args.duration : defaultDuration;
             args.templateUrl = args.templateUrl ? args.templateUrl : defaultTemplateUrl;
             args.container = args.container ? args.container : container;
             args.classes = args.classes ? args.classes : '';


### PR DESCRIPTION
If `args.duration` is zero it will be `false` in javascript world. So we need to check for undefined.
