### PR TITLE
Fix for safari mispositioned message.

### DIFF
--- a/angular-notify.js
+++ b/angular-notify.js
@@ -71,7 +71,7 @@ angular.module('cgNotify', []).factory('notify',['$timeout','$http','$compile','
                 if (scope.$position === 'center'){
                     $timeout(function(){
                         scope.$centerMargin = '-' + (templateElement[0].offsetWidth /2) + 'px';
-                    });
+                    }, 10 /* fixes safari mispositioned message */);
                 }
 
                 scope.$close = function(){


### PR DESCRIPTION
https://github.com/cgross/angular-notify/issues/32

We have same issue with desktop version of safari on OSX El Capitan.